### PR TITLE
Trailing entities after DRVs are labeled O

### DIFF
--- a/ud/nob/no-ud-dev-ner.conllu
+++ b/ud/nob/no-ud-dev-ner.conllu
@@ -1585,8 +1585,8 @@
 14	med	med	ADP	_	_	17	case	_	O
 15	tidligere	tidlig	ADJ	_	Degree=Cmp	16	amod	_	O
 16	Dagsnytt-redaktør	Dagsnytt-redaktør	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	17	appos	_	B-DRV
-17	Per	Per	PROPN	_	Gender=Masc	13	nmod	_	O
-18	Bøhn	Bøhn	PROPN	_	_	17	name	_	O
+17	Per	Per	PROPN	_	Gender=Masc	13	nmod	_	B-PER
+18	Bøhn	Bøhn	PROPN	_	_	17	name	_	I-PER
 19	og	og	CONJ	_	_	13	cc	_	O
 20	70	70	NUM	_	Number=Plur	24	nummod	_	O
 21	-	$-	PUNCT	_	_	20	punct	_	O
@@ -2200,8 +2200,8 @@
 16	,	$,	PUNCT	_	_	5	punct	_	O
 17	sier	si	VERB	_	Mood=Ind|Tense=Pres|VerbForm=Fin	5	parataxis	_	O
 18	NATO-talsmann	NATO-talsmann	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	19	appos	_	B-DRV
-19	James	James	PROPN	_	_	17	nsubj	_	O
-20	Appathurai	Appathurai	PROPN	_	_	19	name	_	O
+19	James	James	PROPN	_	_	17	nsubj	_	B-PER
+20	Appathurai	Appathurai	PROPN	_	_	19	name	_	I-PER
 21	.	$.	PUNCT	_	_	5	punct	_	O
 
 1	Han	han	PRON	_	Animacy=Anim|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	O
@@ -3128,8 +3128,8 @@
 19	.	$.	PUNCT	_	_	6	punct	_	O
 
 1	Venstre-leder	venstre-leder	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	2	appos	_	B-DRV
-2	Lars	Lars	PROPN	_	Gender=Masc	4	nsubj	_	O
-3	Sponheim	Sponheim	PROPN	_	_	2	name	_	O
+2	Lars	Lars	PROPN	_	Gender=Masc	4	nsubj	_	B-PER
+3	Sponheim	Sponheim	PROPN	_	_	2	name	_	I-PER
 4	etterlater	etterlate	VERB	_	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	O
 5	ingen	ingen	DET	_	Gender=Masc|Number=Sing	6	neg	_	O
 6	tvil	tvil	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	4	dobj	_	O
@@ -3155,8 +3155,8 @@
 2	vil	ville	VERB	_	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	O
 3	også	også	ADV	_	_	2	advmod	_	O
 4	KrF-leder	KrF-leder	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	5	appos	_	B-DRV
-5	Dagfinn	Dagfinn	PROPN	_	Gender=Masc	2	nsubj	_	O
-6	Høybråten	Høybråten	PROPN	_	_	5	name	_	O
+5	Dagfinn	Dagfinn	PROPN	_	Gender=Masc	2	nsubj	_	B-PER
+6	Høybråten	Høybråten	PROPN	_	_	5	name	_	I-PER
 7	selv	selv	ADV	_	_	8	advmod	_	O
 8	om	om	SCONJ	_	_	11	mark	_	O
 9	han	han	PRON	_	Animacy=Anim|Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	O
@@ -23841,9 +23841,9 @@
 5	|	$|	SYM	_	_	2	punct	_	O
 
 1	Tønsberg-ordfører	Tønsberg-ordfører	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	2	appos	_	B-DRV
-2	Per	Per	PROPN	_	Gender=Masc	9	nsubj	_	O
-3	Arne	Arne	PROPN	_	Gender=Masc	2	name	_	O
-4	Olsen	Olsen	PROPN	_	_	2	name	_	O
+2	Per	Per	PROPN	_	Gender=Masc	9	nsubj	_	B-PER
+3	Arne	Arne	PROPN	_	Gender=Masc	2	name	_	I-PER
+4	Olsen	Olsen	PROPN	_	_	2	name	_	I-PER
 5	(	$(	PUNCT	_	_	6	punct	_	O
 6	Frp	Frp	PROPN	_	_	2	nmod	_	B-ORG
 7	)	$)	PUNCT	_	_	6	punct	_	O

--- a/ud/nob/no-ud-dev-ner.conllu
+++ b/ud/nob/no-ud-dev-ner.conllu
@@ -2146,7 +2146,7 @@
 7	til	til	ADP	_	_	10	case	_	O
 8	den	den	DET	_	Gender=Masc|Number=Sing|PronType=Dem	10	det	_	O
 9	NATO-ledede	NATO-lede	ADJ	_	Definite=Def|Number=Sing	10	amod	_	B-DRV
-10	ISAF-styrken	ISAF-styrke	NOUN	_	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	O
+10	ISAF-styrken	ISAF-styrke	NOUN	_	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	B-DRV
 11	i	i	ADP	_	_	12	case	_	O
 12	Afghanistan	Afghanistan	PROPN	_	_	10	nmod	_	B-GPE_LOC
 13	.	$.	PUNCT	_	_	5	punct	_	O

--- a/ud/nob/no-ud-test-ner.conllu
+++ b/ud/nob/no-ud-test-ner.conllu
@@ -23171,7 +23171,7 @@
 6	at	at	SCONJ	_	_	11	mark	_	O
 7	VIF-keeper	VIF-keeper	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	8	appos	_	B-DRV
 8	Patrick	Patrick	PROPN	_	_	11	nsubj	_	B-PER
-9	DesRochers	DesRochers	PROPN	_	_	8	name	_	B-PER
+9	DesRochers	DesRochers	PROPN	_	_	8	name	_	I-PER
 10	har	ha	AUX	_	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	O
 11	skrevet	skrive	VERB	_	VerbForm=Part	3	csubj	_	O
 12	under	under	ADP	_	_	11	compound:prt	_	O

--- a/ud/nob/no-ud-test-ner.conllu
+++ b/ud/nob/no-ud-test-ner.conllu
@@ -4137,8 +4137,8 @@
 10	minner	minne	VERB	_	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	O
 11	om	om	ADP	_	_	15	case	_	O
 12	SA-mannen	SA-mann	NOUN	_	Definite=Def|Gender=Masc|Number=Sing	13	appos	_	B-DRV
-13	Horst	Horst	PROPN	_	_	15	det	_	O
-14	Wessels	Wessel	PROPN	_	Case=Gen	13	name	_	O
+13	Horst	Horst	PROPN	_	_	15	det	_	B-PER
+14	Wessels	Wessel	PROPN	_	Case=Gen	13	name	_	I-PER
 15	skjebne	skjebne	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	10	nmod	_	O
 16	,	$,	PUNCT	_	_	10	punct	_	O
 17	og	og	CONJ	_	_	10	cc	_	O
@@ -6653,7 +6653,7 @@
 22	at	at	SCONJ	_	_	30	mark	_	O
 23	de	de	DET	_	Number=Plur|PronType=Dem	24	det	_	O
 24	Fortodol-kapslene	Fortodol-kapsel	NOUN	_	Definite=Def|Gender=Masc|Number=Plur	30	nsubj	_	B-DRV
-25	Sverre	Sverre	PROPN	_	Gender=Masc	27	nsubj	_	O
+25	Sverre	Sverre	PROPN	_	Gender=Masc	27	nsubj	_	B-PER
 26	har	ha	AUX	_	Mood=Ind|Tense=Pres|VerbForm=Fin	27	aux	_	O
 27	spist	spise	VERB	_	VerbForm=Part	24	acl:relcl	_	O
 28	,	$,	PUNCT	_	_	24	punct	_	O
@@ -23170,8 +23170,8 @@
 5	klart	klar	ADJ	_	Definite=Ind|Degree=Pos|Gender=Neut|Number=Sing	3	xcomp	_	O
 6	at	at	SCONJ	_	_	11	mark	_	O
 7	VIF-keeper	VIF-keeper	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	8	appos	_	B-DRV
-8	Patrick	Patrick	PROPN	_	_	11	nsubj	_	O
-9	DesRochers	DesRochers	PROPN	_	_	8	name	_	O
+8	Patrick	Patrick	PROPN	_	_	11	nsubj	_	B-PER
+9	DesRochers	DesRochers	PROPN	_	_	8	name	_	B-PER
 10	har	ha	AUX	_	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	_	O
 11	skrevet	skrive	VERB	_	VerbForm=Part	3	csubj	_	O
 12	under	under	ADP	_	_	11	compound:prt	_	O
@@ -24329,8 +24329,8 @@
 3	at	at	SCONJ	_	_	9	mark	_	O
 4	selv	selv	ADV	_	_	6	nmod	_	O
 5	F-35-tilhenger	F-35-tilhenger	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	6	appos	_	B-DRV
-6	Robert	Robert	PROPN	_	Gender=Masc	9	nsubj	_	O
-7	Gates	Gates	PROPN	_	_	6	name	_	O
+6	Robert	Robert	PROPN	_	Gender=Masc	9	nsubj	_	B-PER
+7	Gates	Gates	PROPN	_	_	6	name	_	I-PER
 8	nå	nå	ADV	_	_	9	advmod	_	O
 9	antar	anta	VERB	_	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	_	O
 10	at	at	SCONJ	_	_	13	mark	_	O
@@ -24825,9 +24825,9 @@
 8	.	$.	PUNCT	_	_	2	punct	_	O
 
 1	Midtøsten-ekspert	Midtøsten-ekspert	NOUN	_	Definite=Ind|Gender=Masc|Number=Sing	2	appos	_	B-DRV
-2	Knut	Knut	PROPN	_	Gender=Masc	5	nsubj	_	O
-3	S.	S.	PROPN	_	_	2	name	_	O
-4	Vikør	Vikør	PROPN	_	_	2	name	_	O
+2	Knut	Knut	PROPN	_	Gender=Masc	5	nsubj	_	B-PER
+3	S.	S.	PROPN	_	_	2	name	_	I-PER
+4	Vikør	Vikør	PROPN	_	_	2	name	_	I-PER
 5	frykter	frykte	VERB	_	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	O
 6	at	at	SCONJ	_	_	14	mark	_	O
 7	sivile	sivil	ADJ	_	Degree=Pos|Number=Plur	14	nsubjpass	_	O


### PR DESCRIPTION
Changed annotations in places where trailing entites after DRVs are labeled as O. 
